### PR TITLE
start.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 	•	Build Tool: Gradle
 	•	Main Endpoint: /hello
 
-# 1. 로컬 실행
+# 로컬 실행
 
 ```
 ./gradlew bootRun
@@ -30,4 +30,10 @@ scp -i <key.pem> app.jar start.sh ubuntu@<EC2_IP>:/home/ubuntu/
 # 원격 실행
 ```
 ssh -i <key.pem> ubuntu@<EC2_IP> "cd /home/ubuntu && chmod +x start.sh && ./start.sh"
+```
+
+# 원격 종료
+
+```
+ssh -i <key.pem> ubuntu@<EC2_IP> "cd /home/ubuntu && chmod +x stop.sh && ./stop.sh"
 ```

--- a/README.md
+++ b/README.md
@@ -21,3 +21,13 @@
 ./gradlew clean bootJar
 java -jar build/libs/hello-api-0.0.1-SNAPSHOT.jar
 ```
+
+# 파일 업로드
+```
+scp -i <key.pem> app.jar start.sh ubuntu@<EC2_IP>:/home/ubuntu/
+```
+
+# 원격 실행
+```
+ssh -i <key.pem> ubuntu@<EC2_IP> "cd /home/ubuntu && chmod +x start.sh && ./start.sh"
+```

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'io.github.hyungjunehong'
-version = '0.1.1'
+version = '0.1.2'
 description = 'Demo project for Spring Boot'
 
 java {

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# ----------------------------------------------------
+# Java 백그라운드 서비스 시작 스크립트 (start.sh)
+# 실행: ./start.sh
+# ----------------------------------------------------
+
+# 실행할 JAR 파일 이름 (스크립트와 같은 경로에 있어야 함)
+JAR_FILE="app.jar"
+# 로그를 저장할 파일 경로
+LOG_FILE="./app_start.log"
+
+echo "--- $JAR_FILE 서비스 시작 중 ---"
+
+# 이미 실행 중인 프로세스가 있는지 확인 (pgrep -f는 명령줄 전체에서 JAR 파일명을 찾음)
+PID=$(pgrep -f "$JAR_FILE")
+
+if [ -n "$PID" ]; then
+    echo "[$JAR_FILE] 서비스가 이미 실행 중입니다. (PID: $PID)"
+    echo "서비스를 중지하려면 stop.sh를 실행하세요."
+else
+    # nohup: 세션이 종료되어도 프로세스가 계속 실행되도록 합니다.
+    # > $LOG_FILE 2>&1: 표준 출력과 표준 에러를 로그 파일로 리디렉션합니다.
+    # &: 명령을 백그라운드로 실행합니다.
+    nohup java -jar "$JAR_FILE" > "$LOG_FILE" 2>&1 &
+    
+    # 프로세스 시작 후 PID 확인을 위해 잠시 대기
+    sleep 2
+    
+    NEW_PID=$(pgrep -f "$JAR_FILE")
+    
+    if [ -n "$NEW_PID" ]; then
+        echo "[$JAR_FILE] 서비스가 백그라운드에서 성공적으로 시작되었습니다. (PID: $NEW_PID)"
+        echo "로그 파일: $LOG_FILE"
+    else
+        echo "[$JAR_FILE] 서비스 시작에 실패했습니다. 로그 파일($LOG_FILE)을 확인하십시오."
+    fi
+fi

--- a/stop.sh
+++ b/stop.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# ----------------------------------------------------
+# Java 백그라운드 서비스 중지 스크립트 (stop.sh)
+# 실행: ./stop.sh
+# ----------------------------------------------------
+
+# 중지할 JAR 파일 이름 (start.sh와 동일해야 함)
+JAR_FILE="app.jar"
+
+echo "--- $JAR_FILE 서비스 중지 중 ---"
+
+# 실행 중인 프로세스의 PID를 찾습니다.
+PID=$(pgrep -f "$JAR_FILE")
+
+if [ -z "$PID" ]; then
+    echo "[$JAR_FILE] 서비스가 실행 중이지 않습니다."
+else
+    echo "[$JAR_FILE] 실행 중인 프로세스를 발견했습니다. (PID: $PID)"
+    echo "프로세스 종료 신호(SIGTERM) 전송 중..."
+    
+    # 프로세스에 종료 신호(SIGTERM)를 보냅니다.
+    kill "$PID"
+    
+    # 프로세스가 완전히 종료될 때까지 최대 10초 대기
+    COUNT=0
+    while kill -0 "$PID" 2>/dev/null; do
+        sleep 1
+        COUNT=$((COUNT + 1))
+        
+        if [ "$COUNT" -ge 10 ]; then
+            echo "프로세스가 10초 내에 종료되지 않았습니다. 강제 종료(kill -9) 시도..."
+            kill -9 "$PID"
+            break
+        fi
+    done
+    
+    if [ -z "$(pgrep -f "$JAR_FILE")" ]; then
+        echo "[$JAR_FILE] 서비스가 성공적으로 중지되었습니다."
+    else
+        echo "[$JAR_FILE] 서비스 중지에 실패했습니다."
+    fi
+fi
+


### PR DESCRIPTION
 - [ ]  원격이나 Jenkins 등에서 사용 가능한 스프링 부터 start, stop script 를 작성

- [ ]  원격에서 해당 스크립트로 start, stop 가능하도록

 start.sh
~~~
#!/bin/bash
# ----------------------------------------------------
# Java 백그라운드 서비스 시작 스크립트 (start.sh)
# 실행: ./start.sh
# ----------------------------------------------------

# 실행할 JAR 파일 이름 (스크립트와 같은 경로에 있어야 함)
JAR_FILE="app.jar"
# 로그를 저장할 파일 경로
LOG_FILE="./app_start.log"

echo "--- $JAR_FILE 서비스 시작 중 ---"

# 이미 실행 중인 프로세스가 있는지 확인 (pgrep -f는 명령줄 전체에서 JAR 파일명을 찾음)
PID=$(pgrep -f "$JAR_FILE")

if [ -n "$PID" ]; then
    echo "[$JAR_FILE] 서비스가 이미 실행 중입니다. (PID: $PID)"
    echo "서비스를 중지하려면 stop.sh를 실행하세요."
else
    # nohup: 세션이 종료되어도 프로세스가 계속 실행되도록 합니다.
    # > $LOG_FILE 2>&1: 표준 출력과 표준 에러를 로그 파일로 리디렉션합니다.
    # &: 명령을 백그라운드로 실행합니다.
    nohup java -jar "$JAR_FILE" > "$LOG_FILE" 2>&1 &
    
    # 프로세스 시작 후 PID 확인을 위해 잠시 대기
    sleep 2
    
    NEW_PID=$(pgrep -f "$JAR_FILE")
    
    if [ -n "$NEW_PID" ]; then
        echo "[$JAR_FILE] 서비스가 백그라운드에서 성공적으로 시작되었습니다. (PID: $NEW_PID)"
        echo "로그 파일: $LOG_FILE"
    else
        echo "[$JAR_FILE] 서비스 시작에 실패했습니다. 로그 파일($LOG_FILE)을 확인하십시오."
    fi
fi
~~~